### PR TITLE
wrap var in quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ disconnect" logs. You can filter these by exporting the following filter
 string:
 
 ```
-export LOG_FILTER_REGEX="(lost connection after CONNECT from |(dis)?connect from )"
+export LOG_FILTER_REGEX="(lost connection after |(dis)?connect from )"
 ```
 
 Postfix version needs to be > 3.4 (from that version the logging at /dev/stdout

--- a/postfix
+++ b/postfix
@@ -23,6 +23,6 @@ postconf -e "relayhost = ${RELAYHOST}"
 postconf -e "debug_peer_list = ${DEBUG_PEER_LIST}"
 
 # run postfix
-/usr/sbin/postfix start-fg 2>&1 | rg --line-buffered -v ${LOG_FILTER_REGEX:-"^$"} &
+/usr/sbin/postfix start-fg 2>&1 | rg --line-buffered -v "${LOG_FILTER_REGEX:-"^$"}" &
 
 wait ${!}


### PR DESCRIPTION
Regex will likely contain special characters that break shell if not
wrapped