### PR TITLE
adding mydestination

### DIFF
--- a/postfix
+++ b/postfix
@@ -17,6 +17,7 @@ trap 'shutdown' HUP INT QUIT KILL TERM
 
 postconf -e "smtp_sasl_password_maps = static:${SMTP_SASL_PASSWORD_MAPS}"
 postconf -e "myhostname = ${MYHOSTNAME}"
+postconf -e "mydestination = localhost, ${MYDESTINATION}"
 postconf -e "myorigin = ${MYORIGIN}"
 postconf -e "mynetworks = ${MYNETWORKS}"
 postconf -e "relayhost = ${RELAYHOST}"


### PR DESCRIPTION
mydestination  is necessary when using this smarthost as MX - even if the goal is to forward this email to an external destination mapped via "virtual_alias_maps" 
