### PR TITLE
fixing the duplicated header reply-to

### DIFF
--- a/postfix
+++ b/postfix
@@ -45,7 +45,7 @@ if [[ -n ${SENDER_CANONICAL_ADDRESS} ]]; then
   echo "/.*/    ${SENDER_CANONICAL_ADDRESS}" > /etc/postfix/sender_canonical
   echo '/^From:(.*)<\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b>/ REPLACE From:$1<'${SENDER_CANONICAL_ADDRESS}'>' > /etc/postfix/second_header_checks
   echo '/(.*)/  prepend X-Envelope-From: <$1>' > /etc/postfix/sender_access
-  echo '/^From: (.*)/ PREPEND Reply-to: $1' > /etc/postfix/header_checks
+  echo '/^From: (.*)/ REPLACE Reply-to: $1' > /etc/postfix/header_checks
 fi
 
 ## run 'virtual' watcher


### PR DESCRIPTION
This is the proposed changed in order to avoid duplicated headers "Reply-to"
Since we are replacing the "/^From: (.*)"  the condition of /etc/postfix/header_checks will always be triggered. 
However, if the header "Reply-to"  is present, it will be replaced rather then added. 
If it is not there, It will be added. 

http://www.postfix.org/header_checks.5.html

```
REPLACE text...
Replace the current line with the specified  text,  and  inspect
 the next input line.
```

Tests:
1:  when Reply-to is not present on the header:
example: 
/tmp/test is :

```
From: "bah bah bah" <invoicing@uuuuuuuuuuuuu.com>
```
Result: 
```
postmap -q - regexp:/etc/postfix/header_checks < /tmp/test.txt 
From: "bah bah bah" <invoicing@uuuuuuuuuuuuu.com>	REPLACE Reply-to: "bah bah bah" <invoicing@uuuuuuuuuuuuu.com>
```
2:  When Reply-to is *not* present on the header:

Example:  
/tmp/test is 
``` 
From: "bah bah bah" <invoicing@uuuuuuuuuuuuu.com>
Reply-to: "No Reply" <noreply@uuuuuuuuuuuuu.com>
```

Result: 
````
/ # postmap -q - regexp:/etc/postfix/header_checks < /tmp/test.txt 
From: "bah bah bah" <invoicing@uuuuuuuuuuuuu.com>	REPLACE Reply-to: "bah bah bah" <invoicing@uuuuuuuuuuuuu.com>
/ # 
``` 

