### PR TITLE
use start-fg command / log to stdout

### DIFF
--- a/etc/postfix/main.cf
+++ b/etc/postfix/main.cf
@@ -49,10 +49,7 @@ compatibility_level=2
 recipient_canonical_maps = regexp:/etc/postfix/canonical
 
 ## Run in a container
-##
-## Log to a file so prometheus exporter can tail the file and export metrics
-## from it
-maillog_file = /var/log/maillog
+maillog_file = /dev/stdout
 
 ## SES envelope rewrite
 ## https://serverfault.com/questions/499955/aws-ses-email-address-is-not-verified-error-with-postfix-relay

--- a/postfix
+++ b/postfix
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -e
+set -e -o pipefail
 
 log() {
   echo "$(date -I'seconds') $1"
@@ -61,8 +61,7 @@ if [[ -n ${VIRTUAL_LOC} ]]; then
 fi
 
 ## run postfix
-/usr/sbin/postfix start
-
-## tail the log file
-touch /var/log/maillog
-tail -f /var/log/maillog
+##
+## stderr + stdout are written to /var/log/maillog so the prometheus exporter can
+## tail the file and export metrics from it
+/usr/sbin/postfix start-fg 2>&1 | tee /var/log/maillog


### PR DESCRIPTION
This ensures that if postfix crashes, the container crashes with it. ~This
does mean that tail can crash and go unnoticed, but that seems preferable
to having no postfix (also I suspect tail is much less likely to crash
compared to postfix)~

