### PR TITLE
rebuild aliases immediately if they are already available

### DIFF
--- a/postfix
+++ b/postfix
@@ -58,6 +58,13 @@ if [[ -n ${VIRTUAL_LOC} ]]; then
     cp '${VIRTUAL_LOC}' /etc/postfix/virtual
     postmap /etc/postfix/virtual
   fi' > /reload && chmod +x /reload && inotifyd /reload $(dirname ${VIRTUAL_LOC}):y &
+
+  ## rebuild immediately if the file already exists
+  if [[ -e ${VIRTUAL_LOC} ]]; then
+    echo "${VIRTUAL_LOC} already exists, rebuilding"
+    cp "${VIRTUAL_LOC}" /etc/postfix/virtual
+    postmap /etc/postfix/virtual
+  fi
 fi
 
 ## run postfix


### PR DESCRIPTION
On pod restart, it takes a small amount of time for the aliases file
to appear - as such, inotifyd tends to trigger the reload script and
everything is normal.

On container restart $VIRTUAL_LOC may already exist - as such we may
have to wait an extended period of time before inotifyd kicks in. We
can mitigate this by doing (most) of what `/reload` does immediately.

---

The issue this deals with is we've started to see the following after container restart:

```
Nov 04 09:16:05 email postfix/trivial-rewrite[9589]: error: open database /etc/postfix/virtual.db: No such file or directory
Nov 04 09:16:05 email postfix/trivial-rewrite[9589]: warning: hash:/etc/postfix/virtual is unavailable. open database /etc/postfix/virtual.db: No such file or directory
Nov 04 09:16:05 email postfix/trivial-rewrite[9589]: warning: virtual_alias_domains: hash:/etc/postfix/virtual: table lookup problem
Nov 04 09:16:05 email postfix/trivial-rewrite[9589]: warning: virtual_alias_domains lookup failure
```

I sort of thought `/etc/postfix/virtual.db` would persist container "restart" - at least that is the behaviour I observe when stopping & starting a local docker container. However I guess k8s might be starting a fresh container?