### PR TITLE
ignore reply-to headers to avoid duplication

### DIFF
--- a/postfix
+++ b/postfix
@@ -42,7 +42,8 @@ if [[ -n ${SENDER_CANONICAL_ADDRESS} ]]; then
   echo "/.*/    ${SENDER_CANONICAL_ADDRESS}" > /etc/postfix/sender_canonical
   echo '/^From:(.*)<\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b>/ REPLACE From:$1<'${SENDER_CANONICAL_ADDRESS}'>' > /etc/postfix/second_header_checks
   echo '/(.*)/  prepend X-Envelope-From: <$1>' > /etc/postfix/sender_access
-  echo '/^From: (.*)/ REPLACE Reply-to: $1' > /etc/postfix/header_checks
+  echo '/^From: (.*)/ REPLACE Reply-To: $1' > /etc/postfix/header_checks
+  echo '/^Reply-To: .*/ IGNORE' >> /etc/postfix/header_checks
 fi
 
 ## run 'virtual' watcher


### PR DESCRIPTION
Duplicate `Reply-To` header errors are still being logged after #15 

My understanding of the `REPLACE` directive is it replaces the current line _not another line that already carries the replacement header_

http://www.postfix.org/header_checks.5.html states:

> Each message header or message body line is compared against a list  of patterns.   When a match is found the corresponding action is executed,  and the matching process is repeated for the  next  message  header  or message body line.

>  For  each  line of message input, the patterns are applied in the order as specified in the table. When a pattern is  found  that  matches  the input  line,  the  corresponding  action  is executed and then the next input line is inspected.

> REPLACE text...
> Replace the current line with the specified text,  and inspect the next input line.

> IGNORE
> Delete the current  line  from the input, and inspect the next input line. See STRIP for an alternative that logs the action.

With all that in mind, the IGNORE line shouldn't impact the `Reply-To` we've written into the original `From:` header line.

```
/ # cat /etc/postfix/header_checks 
/^From: (.*)/ REPLACE Reply-To: $1
/^Reply-To: .*/ IGNORE
/ # postmap -q - regexp:/etc/postfix/header_checks <<EOL
> From: "Original Sender" <original.sender@example.com>
> Reply-To: "Original Reply To" <original.reply.to@example.com>
> EOL
From: "Original Sender" <original.sender@example.com>   REPLACE Reply-To: "Original Sender" <original.sender@example.com>
Reply-To: "Original Reply To" <original.reply.to@example.com>   IGNORE
```

P.S. I suspect the optimal behaviour is to retain the original `Reply-To` header and not add our own - so I might revisit this, however I'm keen to just avoid bounces for the time being