### PR TITLE
Strip DKIM-Signature to prevent bounces

### DIFF
--- a/postfix
+++ b/postfix
@@ -47,6 +47,7 @@ if [[ -n ${SENDER_CANONICAL_ADDRESS} ]]; then
   echo '/(.*)/  prepend X-Envelope-From: <$1>' > /etc/postfix/sender_access
   echo '/^From: (.*)/ REPLACE Reply-To: $1' > /etc/postfix/header_checks
   echo '/^Reply-To: .*/ IGNORE' >> /etc/postfix/header_checks
+  echo '/^DKIM-Signature: .*/ IGNORE' >> /etc/postfix/header_checks
 fi
 
 ## run 'virtual' watcher


### PR DESCRIPTION
```
May 23 12:22:24 email postfix/cleanup[48339]: EB3F0147D: replace: header From: LinkedIn Messages <security-noreply@linkedin.com> from maila-ge.linkedin.com[108.174.0.133]; from=<postmaster@uw.partners> to=<nicjones@uw.partners> proto=ESMTP helo=<maila-ge.linkedin.com>: Reply-To: LinkedIn Messages <security-noreply@linkedin.com>
May 23 12:22:24 email postfix/cleanup[48339]: EB3F0147D: message-id=<81697065.190980.1653308541709@lva1-app72755.prod.linkedin.com>
May 23 12:22:24 email postfix/qmgr[35728]: EB3F0147D: from=<postmaster@uw.partners>, size=27346, nrcpt=1 (queue active)
May 23 12:22:24 email postfix/smtp[48340]: EB3F0147D: to=<nicjones@uw.co.uk>, orig_to=<nicjones@uw.partners>, relay=email-smtp.eu-west-1.amazonaws.com[34.251.18.141]:587, delay=0.98, delays=0.64/0/0.25/0.1, dsn=5.0.0, status=bounced (host email-smtp.eu-west-1.amazonaws.com[34.251.18.141] said: 554 Transaction failed: Duplicate header 'DKIM-Signature'. (in reply to end of DATA command))
```

I suspect we're setting the header, and also incorrectly looking to forward the original one too.